### PR TITLE
use HTTPS for image in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Storybook README addon
 This project is based on [tuchk4/storybook-readme](https://github.com/tuchk4/storybook-readme)
 
-![Storybook README addon](http://bvap-sg.s3.amazonaws.com/assets/images/bvap-storybook-readme.jpg)
+![Storybook README addon](https://user-images.githubusercontent.com/42671/132272183-96470ca2-5baa-49af-b8f1-d811a78969bc.jpg)
 
 [Example Storybook with README addon](https://baktiaditya.github.io/bvap-storybook-readme/?knob-alert=false&knob-success=false&knob-text=Hello%20Im%20Button&selectedKind=Custom%20Preview%20and%20Footer&selectedStory=Button&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybook%2Factions%2Factions-panel)
 


### PR DESCRIPTION
One of the REAMDE images is using HTTP. The Storybook addon catalog recommends using HTTPS images.

This PR updates it to an HTTPS url.